### PR TITLE
Add support for pdf.customSize

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -49,6 +49,7 @@ PDF Output can be customized using a set of options in the `book.json`:
 | `pdf.fontSize` | Base font size (default is `12`) |
 | `pdf.fontFamily` | Base font family (default is `Arial`) |
 | `pdf.paperSize` | Paper size, options are `'a0', 'a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'b0', 'b1', 'b2', 'b3', 'b4', 'b5', 'b6', 'legal', 'letter'` (default is `a4`) |
+| `pdf.customSize` | Custom size, overrides paperSize.  eg: `8.5x10.5` |
 | `pdf.margin.top` | Top margin (default is `56`) |
 | `pdf.margin.bottom` | Bottom margin (default is `56`) |
 | `pdf.margin.right` | Right margin (default is `62`) |

--- a/lib/constants/configSchema.js
+++ b/lib/constants/configSchema.js
@@ -113,6 +113,10 @@ module.exports = {
                     'default': 'a4',
                     'title': 'Paper size for the PDF'
                 },
+                'customSize': {
+                    'type': 'string',
+                    'title': 'Custom paper size for the PDF.  Overrides paperSize.  eg: 6.0x9.0'
+                },
                 'chapterMark': {
                     'type': 'string',
                     'enum': ['pagebreak', 'rule', 'both', 'none'],

--- a/lib/output/ebook/getConvertOptions.js
+++ b/lib/output/ebook/getConvertOptions.js
@@ -50,7 +50,7 @@ function getConvertOptions(output) {
         .spread(function(headerTpl, footerTpl) {
             var pdfOptions = config.getValue('pdf').toJS();
 
-            return options = extend(options, {
+            options = extend(options, {
                 '--chapter-mark':           String(pdfOptions.chapterMark),
                 '--page-breaks-before':     String(pdfOptions.pageBreaksBefore),
                 '--margin-left':            String(pdfOptions.margin.left),
@@ -65,6 +65,10 @@ function getConvertOptions(output) {
                 '--pdf-header-template':    headerTpl,
                 '--pdf-footer-template':    footerTpl
             });
+            if (pdfOptions.customSize) {
+                options['--custom-size'] = String(pdfOptions.customSize);
+            }
+            return options;
         });
     });
 }


### PR DESCRIPTION
This commits adds a new property `pdf.customSize` which is basically a port of the initial pull request https://github.com/GitbookIO/gitbook/pull/1694 that never got landed because gitbook is no longer maintained.