### PR TITLE
package.json: add engines key

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "description": "Library and cmd utility to generate GitBooks",
   "main": "lib/index.js",
   "browser": "./lib/browser.js",
+  "engines": {
+    "node": "10"
+  },
   "dependencies": {
     "bash-color": "0.0.4",
     "cheerio": "0.20.0",


### PR DESCRIPTION
Edit `package.json` to make it explicit that this project requires Node.js v10 to run. It actually runs in v11 as well, but since that version has been unsupported since June 2019, it's best not to recommend it. Version 10 is also EOL'd at the time of writing, but at least it was an LTS and was supported until April 2021.